### PR TITLE
Fix missing database module

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,15 @@
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy.orm import sessionmaker
+from contextlib import asynccontextmanager
+
+from .config import settings
+
+# Async engine and sessionmaker are shared across the app
+engine = create_async_engine(settings.DATABASE_URL, echo=False, future=True)
+async_session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+@asynccontextmanager
+async def get_async_session() -> AsyncSession:
+    """Provide a transactional scope around a series of operations."""
+    async with async_session() as session:
+        yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,19 +3,13 @@
 import asyncio
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from .config import settings
 from .models import Base
 from .crud import create_snapshot, read_latest_snapshot
 from .modbus_client import read_registers, modbus_polling_task
-
-# 1. Настраиваем SQLAlchemy Async Engine
-engine = create_async_engine(settings.DATABASE_URL, echo=False, future=True)
-
-# 2. Создаём фабрику сессий. class_=AsyncSession говорит: "сессии будут асинхронными"
-async_session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+from .database import engine, async_session
 
 # 3. Создаём экземпляр FastAPI
 app = FastAPI()

--- a/backend/app/modbus_client.py
+++ b/backend/app/modbus_client.py
@@ -9,7 +9,6 @@ from typing import Optional, List
 
 from .crud import create_snapshot
 from .database import get_async_session
-from sqlalchemy.ext.asyncio import AsyncSession
 
 
 async def read_registers() -> Optional[List[int]]:


### PR DESCRIPTION
## Summary
- add a shared `database.py` module with async session
- update `main.py` and `modbus_client.py` to use the new module

## Testing
- `uvicorn app.main:app --reload` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68449073352c832a8de4f84cdd94b569