### PR TITLE
Implement history endpoint and logging

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,6 +27,10 @@ class Settings(BaseSettings):
         "http://127.0.0.1:5173"
     ]
 
+    # Файл для логов
+    LOG_FILE: str = "app.log"
+    LOG_LEVEL: str = "INFO"
+
 
 # Создаём один экземпляр настроек, чтобы можно было импортировать везде:
 settings = Settings()

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -3,9 +3,12 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy import desc
+import logging
 
 from .models import LatestValues
-from typing import Optional
+from typing import Optional, List
+
+logger = logging.getLogger(__name__)
 
 
 async def create_snapshot(db: AsyncSession, registers_list: list[int]) -> LatestValues:
@@ -19,6 +22,7 @@ async def create_snapshot(db: AsyncSession, registers_list: list[int]) -> Latest
     db.add(snapshot)               # готовим к вставке в базу
     await db.commit()              # сохраняем изменения (вставляем строку)
     await db.refresh(snapshot)     # обновляем объект из БД, чтобы получить её поля (например, timestamp, id)
+    logger.info("Snapshot created with id %s", snapshot.id)
     return snapshot
 
 
@@ -33,4 +37,19 @@ async def read_latest_snapshot(db: AsyncSession) -> Optional[LatestValues]:
         select(LatestValues).order_by(desc(LatestValues.timestamp)).limit(1)
     )
     # result.scalars().first() вернёт либо объект LatestValues, либо None
-    return result.scalars().first()
+    snapshot = result.scalars().first()
+    if snapshot:
+        logger.debug("Fetched latest snapshot id %s", snapshot.id)
+    else:
+        logger.debug("No snapshots found in database")
+    return snapshot
+
+
+async def read_snapshot_history(db: AsyncSession, limit: int) -> List[LatestValues]:
+    """Return last ``limit`` snapshots ordered by timestamp desc."""
+    result = await db.execute(
+        select(LatestValues).order_by(desc(LatestValues.timestamp)).limit(limit)
+    )
+    snapshots = result.scalars().all()
+    logger.info("Fetched %s snapshots from history", len(snapshots))
+    return snapshots


### PR DESCRIPTION
## Summary
- configure logging to write into `app.log`
- add `LOG_FILE` and `LOG_LEVEL` settings
- log snapshot operations and endpoint calls
- new `read_snapshot_history` helper to fetch history
- add `/history` endpoint returning recent snapshots

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684493575f0c832a9b935fffe67aec79